### PR TITLE
Add timestamp prefix to log output

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -3,13 +3,14 @@ import type { LogParams } from '@/global'
 export const log = (props: LogParams) => {
   const { type, message, jumpLine } = props
 
-  jumpLine === true && console.log('')
+  if (jumpLine) console.log('')
 
-  const date = new Intl.DateTimeFormat('en-GB', { dateStyle: 'short', timeStyle: 'short' }).format(new Date())
+  const timestamp = new Intl.DateTimeFormat('en-GB', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  }).format(new Date())
 
-  // TODO adicionar um prefixo com data e hora e id do processo no Node.js
-  const processId = process.pid // ID do processo no Node.js
-  const prefix = `\x1b[37m[${processId}] - [${date}]\x1b[0m` // Branco para a data e ID
+  const prefix = `\x1b[37m[${process.pid}] - [${timestamp}]\x1b[0m`
 
   switch (type) {
     case 'success':

--- a/tests/unit/common/log.test.ts
+++ b/tests/unit/common/log.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest'
+import { log } from '@/common'
+
+describe('log utility', () => {
+  it('should prefix messages with timestamp and pid', () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    log({ type: 'success', message: 'Test message' })
+
+    expect(spy).toHaveBeenCalled()
+    const [firstArg, secondArg] = spy.mock.calls[0]
+    const regex = new RegExp(`^\\x1b\\[37m\\[${process.pid}\\] - \\[.+\\]\\x1b\\[0m \\x1b\\[32m%s\\x1b\\[0m$`)
+    expect(firstArg).toMatch(regex)
+    expect(secondArg).toBe('Test message')
+
+    spy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Summary
- prefix log messages with timestamp and process id
- test log utility for new prefix

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_6869c94cbfdc832ca7c68e42efdc5bb1