### PR TITLE
Fix query decorator metadata scoping

### DIFF
--- a/src/decorators/query.decorator.ts
+++ b/src/decorators/query.decorator.ts
@@ -7,7 +7,8 @@ function decorator(query?: string) {
       throw new Error(`param decorator @QUERY can only be applied into method params.`)
     }
     // Get the existing query string parameters
-    const queries: QueryParams[] = Reflect.getMetadata('query:metadata', target.constructor) || []
+    const queries: QueryParams[] =
+      Reflect.getMetadata('query:metadata', target.constructor, propertyKey) || []
 
     // Add the new parameter
     queries.push({ index: parameterIndex, name: query })


### PR DESCRIPTION
## Summary
- ensure query decorator retrieves metadata with property key

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_6869c94c2b68832cbeb49aa8fbafb384