### PR TITLE
Add controller flag metadata

### DIFF
--- a/src/decorators/body.decorator.ts
+++ b/src/decorators/body.decorator.ts
@@ -5,6 +5,10 @@ function bodyDecorator(target: Object, propertyKey: string | symbol, parameterIn
     throw new Error(`param decorator @BODY can only be applied into method params.`)
   }
 
+  if (!target.constructor.__isController && !Reflect.getMetadata('controller:metadata', target.constructor)) {
+    throw new Error(`@BODY decorator can only be used within classes decorated with @Controller`)
+  }
+
   const body: any[] = Reflect.getMetadata('body:metadata', target.constructor, propertyKey) || []
 
   body.push(parameterIndex)
@@ -16,5 +20,3 @@ function bodyDecorator(target: Object, propertyKey: string | symbol, parameterIn
  * returns the express request.body object
  */
 export const Body = safeDecorator(bodyDecorator)
-
-//TODO adicionar validacao para so permitir o uso se estiver em uma classe decorada com CONTROLLER

--- a/src/decorators/controller.decorator.ts
+++ b/src/decorators/controller.decorator.ts
@@ -14,6 +14,12 @@ export function Controller(props?: ControllerMetadataParams) {
     const Routes: RouteMetadataProps[] = Reflect.getMetadata('routes:metadata', target) || []
 
     Reflect.defineMetadata('controller:metadata', true, target)
+    Object.defineProperty(target, '__isController', {
+      value: true,
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    })
 
     // Set the prefix path
     let prefix = ''
@@ -44,4 +50,3 @@ export function Controller(props?: ControllerMetadataParams) {
     }
   }
 }
-//TODO registrar uma property na classe decorada para informar que ela e um controller

--- a/tests/unit/decorators/controller.decorator.test.ts
+++ b/tests/unit/decorators/controller.decorator.test.ts
@@ -25,6 +25,7 @@ function Controller(props?: any) {
   return function (target: any) {
     // Definir metadados de controller
     Reflect.defineMetadata('controller:metadata', props, target)
+    Object.defineProperty(target, '__isController', { value: true })
 
     // Obter rotas existentes
     const routes = Reflect.getMetadata('routes:metadata', target) || []
@@ -71,6 +72,13 @@ describe('@Controller', () => {
     const metadata = Reflect.getMetadata('controller:metadata', TesteController)
     expect(metadata).toBeDefined()
     expect(metadata.path).toBe('/teste')
+  })
+
+  it('deve definir a flag __isController na classe', () => {
+    @Controller()
+    class FlagController {}
+
+    expect((FlagController as any).__isController).toBe(true)
   })
 
   it('deve lidar com versão corretamente', () => {


### PR DESCRIPTION
## Summary
- add `__isController` flag when applying `@Controller`
- validate `@Body` usage based on the flag
- test for the new controller flag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869c4535624832c9024d9371fa31d37