### PR TITLE
Add controller validation to Body decorator

### DIFF
--- a/src/decorators/body.decorator.ts
+++ b/src/decorators/body.decorator.ts
@@ -1,6 +1,9 @@
 import { safeDecorator } from './safe-decorator'
 
 function bodyDecorator(target: Object, propertyKey: string | symbol, parameterIndex: number) {
+  if (!Reflect.getMetadata('controller:metadata', target.constructor)) {
+    throw new Error('@BODY can only be used within classes decorated with @Controller.')
+  }
   if (typeof target.constructor.prototype[propertyKey] !== 'function' || typeof parameterIndex !== 'number') {
     throw new Error(`param decorator @BODY can only be applied into method params.`)
   }
@@ -16,5 +19,3 @@ function bodyDecorator(target: Object, propertyKey: string | symbol, parameterIn
  * returns the express request.body object
  */
 export const Body = safeDecorator(bodyDecorator)
-
-//TODO adicionar validacao para so permitir o uso se estiver em uma classe decorada com CONTROLLER

--- a/tests/unit/decorators/body.decorator.real.test.ts
+++ b/tests/unit/decorators/body.decorator.real.test.ts
@@ -1,0 +1,28 @@
+import 'reflect-metadata'
+import { describe, expect, it, vi } from 'vitest'
+import { Body } from '@/decorators/body.decorator'
+
+// helper to apply Body using decorator syntax
+
+describe('Body decorator validation', () => {
+  it('should throw when used outside a controller', () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    expect(() => {
+      class TestClass {
+        method(@Body body: any) {}
+      }
+      // create an instance to avoid unused variable
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const t = new TestClass()
+    }).not.toThrow()
+
+    expect(exitSpy).toHaveBeenCalledWith(1)
+    expect(errorSpy.mock.calls[0][0]).toContain('@BODY can only be used within classes decorated with @Controller.')
+
+    exitSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+
+})


### PR DESCRIPTION
## Summary
- validate Body decorator is used only inside controllers
- test the validation logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869c450f614832c94307f8c5a6fdba4