### PR TITLE
Fix Nespress import syntax in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Make sure to enable these options in your `tsconfig.json`:
 ### Starting the server
 
 ```typescript
-import Nespress from 'nespress'
+import { Nespress } from 'nespress'
 
 const app = new Nespress({ controllers: [] })
 app.start(3000)
@@ -110,7 +110,7 @@ export class UsersController {
 ### Registering the controller
 
 ```typescript
-import Nespress from 'nespress'
+import { Nespress } from 'nespress'
 import { UsersController } from './controllers/users.controller'
 
 const app = new Nespress({

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -59,7 +59,7 @@ Certifique-se de habilitar estas opções no seu `tsconfig.json`:
 ### Iniciando o servidor
 
 ```typescript
-import Nespress from 'nespress'
+import { Nespress } from 'nespress'
 
 const app = new Nespress({ controllers: [] })
 app.start(3000)
@@ -110,7 +110,7 @@ export class UsersController {
 ### Registrando o controlador
 
 ```typescript
-import Nespress from 'nespress'
+import { Nespress } from 'nespress'
 import { UsersController } from './controllers/users.controller'
 
 const app = new Nespress({


### PR DESCRIPTION
## Summary
- fix Nespress import syntax in README
- sync Portuguese README import statement

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_6869c450b6f4832c994397e3498980d9