### PR TITLE
Fix RouteMetadataProps handler typing

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,7 +1,7 @@
 export type RouteMetadataProps = {
   method: 'get' | 'post' | 'put' | 'delete' | 'patch'
   path: string
-  handler: (...params: Parameters) => any
+  handler: (...params: any[]) => unknown
 }
 
 export type QueryParams = {

--- a/tests/integration/basic-controller.test.ts
+++ b/tests/integration/basic-controller.test.ts
@@ -91,7 +91,7 @@ class MockNespressCore {
         // Pegar parâmetros do body
         const bodyParams = Reflect.getMetadata('body:metadata', controller, propertyKey) || []
 
-        this.app[method](path, async (req: any, res: any) => {
+        ;(this.app as any)[method](path, async (req: any, res: any) => {
           try {
             // Constrói os argumentos para o handler
             const args: any[] = []


### PR DESCRIPTION
## Summary
- update RouteMetadataProps.handler to accept an array of parameters
- adjust integration test to satisfy strict typing

## Testing
- `npx tsc -p tsconfig.json`
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_6869c44f6248832c956ebbf6574db5fb