### PR TITLE
Implement error handler utility

### DIFF
--- a/src/common/error-handler.ts
+++ b/src/common/error-handler.ts
@@ -1,0 +1,26 @@
+import type { Response } from 'express'
+
+export interface ErrorHandlerOptions {
+  debug?: boolean
+}
+
+/**
+ * Handles errors and sends a JSON response.
+ *
+ * @param error - The error thrown by the route handler or middleware.
+ * @param res - Express response object used to send the error payload.
+ * @param options - Optional settings such as debug mode.
+ */
+export function handleError(error: any, res: Response, options: ErrorHandlerOptions = {}): void {
+  const statusCode = error?.statusCode ?? 500
+  const debug = options.debug ?? process.env.NODE_ENV !== 'production'
+
+  const payload: Record<string, any> = {
+    message: error?.message ?? 'Erro interno do servidor',
+  }
+
+  if (error?.code !== undefined) payload.code = error.code
+  if (debug && error?.stack) payload.stack = error.stack
+
+  res.status(statusCode).json(payload)
+}

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -27,3 +27,5 @@ export const log = ({ type = 'default', message, jumpLine }: LogParams) => {
       break
   }
 }
+
+export { handleError } from './error-handler'


### PR DESCRIPTION
## Summary
- implement a simple error handler
- export the new utility from `src/common`

## Testing
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_6880d164f65c832cae9fbef35960f65c