### PR TITLE
fix decorator error handling

### DIFF
--- a/src/decorators/safe-decorator.ts
+++ b/src/decorators/safe-decorator.ts
@@ -4,7 +4,7 @@ export function safeDecorator(decorator: Function) {
       decorator(...args)
     } catch (error) {
       console.error(`DecoratorError => ${(error as Error).message}`)
-      process.exit(1)
+      throw error
     }
   }
 }

--- a/tests/unit/decorators/body.decorator.real.test.ts
+++ b/tests/unit/decorators/body.decorator.real.test.ts
@@ -6,22 +6,20 @@ import { Body } from '@/decorators/body.decorator'
 
 describe('Body decorator validation', () => {
   it('should throw when used outside a controller', () => {
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
 
     expect(() => {
       class TestClass {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         method(@Body body: any) {}
       }
       // create an instance to avoid unused variable
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const t = new TestClass()
-    }).not.toThrow()
+    }).toThrow('@BODY can only be used within classes decorated with @Controller.')
 
-    expect(exitSpy).toHaveBeenCalledWith(1)
     expect(errorSpy.mock.calls[0][0]).toContain('@BODY can only be used within classes decorated with @Controller.')
 
-    exitSpy.mockRestore()
     errorSpy.mockRestore()
   })
 


### PR DESCRIPTION
## Summary
- ensure safe decorator throws instead of exiting
- update body decorator test accordingly

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6880d1665330832cb334117b1b87b24b